### PR TITLE
Warning fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.o
 *.swp
+moc-adapter

--- a/Bridge/AllJoynAbout.cpp
+++ b/Bridge/AllJoynAbout.cpp
@@ -94,7 +94,7 @@ QStatus AllJoynAbout::GetDeviceId(std::string& deviceId)
   return st;
 }
 
-QStatus AllJoynAbout::ReadDeviceId(std::string& deviceId)
+QStatus AllJoynAbout::ReadDeviceId(std::string&)
 {
   // TODO read from config
   return ER_FAIL;

--- a/Bridge/Bridge.cpp
+++ b/Bridge/Bridge.cpp
@@ -162,7 +162,7 @@ Leave:
   return ret == 0 ? ER_OK : ER_FAIL;
 }
 
-void Bridge::DeviceSystemBridge::OnAdapterSignal(IAdapterSignal const& signal, void* argp)
+void Bridge::DeviceSystemBridge::OnAdapterSignal(IAdapterSignal const& signal, void*)
 {
   // TODO
   shared_ptr<IAdapterDevice> adapterDevice;

--- a/Bridge/Bridge.h
+++ b/Bridge/Bridge.h
@@ -54,25 +54,36 @@ namespace Bridge
     class AdapterSignalListener : public IAdapterSignalListener
     {
     public:
-      AdapterSignalListener(shared_ptr<DeviceSystemBridge> const& parent)
-        : m_parent(parent) { }
+      AdapterSignalListener(DeviceSystemBridge& parent)
+        : m_parent(parent)
+        , m_shuttingDown(false)
+      {
+      }
 
       virtual void AdapterSignalHandler(IAdapterSignal const& signal, void* argp)
       {
-        shared_ptr<DeviceSystemBridge> dsb = m_parent.lock();
-        if (dsb)
-          dsb->OnAdapterSignal(signal, argp);
+        if (m_shuttingDown)
+        {
+          return;
+        }
+        m_parent.OnAdapterSignal(signal, argp);
+      }
+
+      void Shutdown()
+      {
+        m_shuttingDown = true;
       }
       
     private:
-      weak_ptr<DeviceSystemBridge> m_parent;
+      DeviceSystemBridge& m_parent;
+      bool m_shuttingDown;
     };
 
   private:
     bool                              m_alljoynInitialized;
     shared_ptr<IAdapter>              m_adapter;
     BridgeDeviceList                  m_deviceList;
-    shared_ptr<AdapterSignalListener> m_adapterSignaListener;
+    shared_ptr<AdapterSignalListener> m_adapterSignalListener;
     std::vector<IAdapter::RegistrationHandle> m_registeredSignalListeners;
   };
 }

--- a/Bridge/BridgeConfig.cpp
+++ b/Bridge/BridgeConfig.cpp
@@ -136,7 +136,7 @@ QStatus Bridge::BridgeConfig::FromFile(std::string const& fileName)
     xmlFreeDoc(m_doc);
 
   m_doc = doc;
-  return ER_OK;
+  return st;
 }
 
 QStatus Bridge::BridgeConfig::ToFile(std::string const& fileName)

--- a/Bridge/BridgeDevice.cpp
+++ b/Bridge/BridgeDevice.cpp
@@ -6,7 +6,7 @@ QStatus Bridge::BridgeDevice::Shutdown()
   return st;
 }
 
-QStatus Bridge::BridgeDevice::Initialize(shared_ptr<IAdapterDevice> const& dev)
+QStatus Bridge::BridgeDevice::Initialize(shared_ptr<IAdapterDevice> const&)
 {
   QStatus st = ER_OK;
   return st;

--- a/Common/Guid.h
+++ b/Common/Guid.h
@@ -14,7 +14,7 @@ namespace Common
       uuid_generate_random(uuid);
       
       #ifdef __linux__
-      char* s;
+      char s[37];
       #else
       uuid_string_t s;
       #endif

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ LIBXML_INC=/usr/include/libxml2
 #ALLJOYN_INSTALL_DIR=/Users/jgladi200/Work/alljoyn/alljoyn-15.04.00-src/build/darwin/x86/debug/dist/cpp
 ALLJOYN_INSTALL_DIR=/home/gladish/work/alljoyn-15.09.00-src/build/linux/x86_64/debug/dist/cpp/
 
-CXXFLAGS=-D QCC_OS_GROUP_POSIX -Wall -Wextra -g -std=c++0x -I.  -I$(ALLJOYN_INSTALL_DIR)/inc -I$(LIBXML_INC)
+CXXFLAGS=-D QCC_OS_GROUP_POSIX -Wall -Wextra -Wno-missing-field-initializers -Wno-deprecated-declarations -g -std=c++0x -I. -I$(ALLJOYN_INSTALL_DIR)/inc -I$(LIBXML_INC)
 LDFLAGS=-L $(ALLJOYN_INSTALL_DIR)/lib -lalljoyn -lcrypto -lxml2 -pthread -luuid
-DEV_PROVIDER_OBJS=$(patsubst %.cpp, %.o,$(SRCS))
+DEV_PROVIDER_OBJS=$(patsubst %.cpp, %.o, $(SRCS))
 OBJS=$(DEV_PROVIDER_OBJS)
 
 all: moc-adapter 
@@ -26,8 +26,6 @@ all: moc-adapter
 clean:
 	$(RM) MockAdapter core DeviceProviders/*.o Bridge/*.o Common/*.o Adapters/MockAdapter/*.o
 
-
 moc-adapter: $(OBJS)
 	$(CXX) -o $@ $^ $(LDFLAGS)
-
 

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ LDFLAGS=-L $(ALLJOYN_INSTALL_DIR)/lib -lalljoyn -lcrypto -lxml2 -pthread -luuid
 DEV_PROVIDER_OBJS=$(patsubst %.cpp, %.o, $(SRCS))
 OBJS=$(DEV_PROVIDER_OBJS)
 
-all: moc-adapter 
+all: moc-adapter
 
 clean:
-	$(RM) MockAdapter core DeviceProviders/*.o Bridge/*.o Common/*.o Adapters/MockAdapter/*.o
+	$(RM) moc-adapter *.o DeviceProviders/*.o Bridge/*.o Common/*.o Adapters/MockAdapter/*.o
 
 moc-adapter: $(OBJS)
 	$(CXX) -o $@ $^ $(LDFLAGS)


### PR DESCRIPTION
These are just a few fixes to make this build with no warnings (on Fedora 23 at least). I tried to leave the `-W` options alone, since I assume you want `-Wextra` enabled, but I had to turn off `-Wdeprecated-declarations`, since Alljoyn has one (PropertyChanged) and a warning that triggers for every file isn't very useful. I also turned off `-Wmissing-field-initializers`, since partial initializers are well-defined (not an error), and they're used in MockDevices.cpp.

I also fixed `make clean` to remove top-level *.o files and the built program (moc-adapter).